### PR TITLE
Make `quickcheck` a normal dependency

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -17,10 +17,10 @@
   "dependencies": {
     "purescript-console": "^5.0.0",
     "purescript-foldable-traversable": "^5.0.0",
-    "purescript-distributive": "^5.0.0"
+    "purescript-distributive": "^5.0.0",
+    "purescript-quickcheck": "^7.0.0"
   },
   "devDependencies": {
-    "purescript-quickcheck": "^7.0.0",
     "purescript-quickcheck-laws": "^6.0.0",
     "purescript-assert": "^5.0.0",
     "purescript-psci-support": "^5.0.0"


### PR DESCRIPTION
I was pretty sure about this since I had ran `grep quickcheck -r src`, but it turns out I forgot to pass `-i` (case insensitivity) to the grep command. My brain at its finest.